### PR TITLE
Make scripts cross platform

### DIFF
--- a/collect/collect.py
+++ b/collect/collect.py
@@ -1,6 +1,7 @@
 """Provides functions for downloading images"""
 import os
 import pathlib
+import shutil
 from urllib.parse import urlparse
 
 from . import util
@@ -82,9 +83,8 @@ class Collect(os.PathLike):
 
     def empty(self):
         """Remove each file in this directory."""
-        for file in self.path.iterdir():
-            logging.info('Removing %s', file)
-            util.disown('rm', '-f', file)
+        shutil.rmtree(self.path)
+        self.path.mkdir()
 
     def random(self):
         return next(util.randomized(self.path.iterdir()))

--- a/collect/config.py
+++ b/collect/config.py
@@ -1,7 +1,13 @@
 """Global package settings"""
+import os
 import pathlib
 
-__all__ = ['DIRECTORY', 'REDDIT_URL']
+__all__ = ['DIRECTORY', 'REDDIT_URL', 'WINDOWS']
 
-DIRECTORY = str(pathlib.Path.home() / '.cache/collect')
 REDDIT_URL = 'https://www.reddit.com/r/earthporn/hot/.json?limit=10'
+WINDOWS = os.name == 'nt'
+
+if WINDOWS:
+    DIRECTORY = str(pathlib.Path.home() / 'Pictures/collect')
+else:
+    DIRECTORY = str(pathlib.Path.home() / '.cache/collect')


### PR DESCRIPTION
* Cross platform `shlex.split`, `os.setpgrp`, `/dev/null`, and `nohup` adaptations
* Standard library `shutil.rmtree` function in place of `rm` shell command
* Different default directory for Windows
* Adapt to different Windows `ping` flags
* Global Windows boolean value